### PR TITLE
Save revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the source for tooling for naively turning documents and rich text field
 
 This builds heavily on Sanity's [blocks-to-html](https://github.com/sanity-io/block-content-to-html) and [block-tools](https://github.com/sanity-io/sanity/tree/next/packages/@sanity/block-tools), and it's highly recommended you familiarize yourself with these if you plan on customizing.
 
-If you're using any of our `TranslationsTab` plugins, the scenarios below are some you might enocunter in your journey!
+If you're using any of our `TranslationsTab` plugins, the scenarios below are some you might encounter on your journey!
 
 ### Scenario: Some fields or objects in my document are serializing /deserializing strangely.
 First: this is often caused by not declaring types at the top level of your schema. Serialization introspects your schema files and can get a much better sense of what to do when objects are not "anonymous" (this is similar to how our GraphQL functions work -- more info on "strict" schemas [here](https://www.sanity.io/docs/graphql#33ec7103289a)) You can save yourself some development time by trying this first.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.6",
+  "version": "0.2.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/BaseDocumentSerializer.ts
+++ b/src/BaseDocumentSerializer.ts
@@ -50,14 +50,27 @@ const serializeDocument = async (
     }
   }
 
+  const rawHTMLBody = document.createElement('body')
+  rawHTMLBody.innerHTML = serializeObject(
+    serializedFields,
+    doc._type,
+    stopTypes,
+    serializers
+  )
+
+  //include _rev of doc as meta
+  const rawHTMLHead = document.createElement('head')
+  const revMeta = document.createElement('meta')
+  revMeta.setAttribute('_rev', doc._rev)
+  rawHTMLHead.appendChild(revMeta)
+
+  const rawHTML = document.createElement('html')
+  rawHTML.appendChild(rawHTMLHead)
+  rawHTML.appendChild(rawHTMLBody)
+
   return {
     name: documentId,
-    content: serializeObject(
-      serializedFields,
-      doc._type,
-      stopTypes,
-      serializers
-    ),
+    content: rawHTML.outerHTML,
   }
 }
 
@@ -192,7 +205,7 @@ const serializeObject = (
             stopTypes,
             serializers
           )
-          htmlField = `<div class=${fieldName}>${objHTML}</div>`
+          htmlField = `<div class="${fieldName}">${objHTML}</div>`
         }
       }
       innerHTML += htmlField

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,11 +1,14 @@
 import sanityClient from 'part:@sanity/base/client'
 import { SanityDocument } from '@sanity/types'
 
-const client = sanityClient.withConfig({ apiVersion: 'v1' })
+const client = sanityClient.withConfig({ apiVersion: '2021-03-25' })
 
-export const findLatestDraft = (documentId: string) => {
-  const query = `*[_id match $id && (_id in path("drafts.*") || _id in path("*"))]`
-  const params = { id: documentId }
+export const findLatestDraft = (documentId: string, ignoreI18n = true) => {
+  //eliminates i18n versions
+  const query = `*[_id match $id ${
+    ignoreI18n ? ' && (_id in path("drafts.*") || _id in path("*"))' : ''
+  }]`
+  const params = { id: `*${documentId}` }
   return client
     .fetch(query, params)
     .then(


### PR DESCRIPTION
Tracks revision in HTML meta head, pulls that meta out during deserialization, and fetches correct revision on patch.