### PR TITLE
fix: bump "@sanity/schema" dependency version to resolve invalid export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sanity/block-tools": "^3.3.1",
         "@sanity/incompatible-plugin": "^1.0.4",
         "@sanity/mutator": "^3.3.1",
-        "@sanity/schema": "3.3.1",
+        "@sanity/schema": "3.4.0",
         "just-clone": "^6.2.0",
         "sanity": "^3"
       },
@@ -3855,6 +3855,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@sanity/client/-/client-4.0.1.tgz",
       "integrity": "sha512-Sd/oGzDsZulodtjq54wOFoMSvUrNnXkvevAGmuLmO90givXHzEyMMUFSj/BmG6TV1mKigS0m6gmFDP/dalUHjg==",
+      "dev": true,
       "dependencies": {
         "@sanity/eventsource": "^4.0.0",
         "get-it": "^7.0.2",
@@ -3869,6 +3870,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-4.0.0.tgz",
       "integrity": "sha512-W0AD141JILOySJ177j2+HTr5k4tWNyXjGsr0dDXJzpqlwZ09J/uPHI73hMe5XtoFumPa9Bj6jy8uu2qdZX84NQ==",
+      "dev": true,
       "dependencies": {
         "event-source-polyfill": "1.0.25",
         "eventsource": "^2.0.2"
@@ -3878,6 +3880,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3894,6 +3897,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "dev": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -3902,6 +3906,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/get-it/-/get-it-7.0.2.tgz",
       "integrity": "sha512-q4d+ssYtpWzC4/qJ4aJDZ5yWl94BIGmRER7PEvYpiKCBoCoDnl1YygEvNHQ2tHbD3GVZaq3QonKGi6Puh1Hzkw==",
+      "dev": true,
       "dependencies": {
         "@sanity/timed-out": "^4.0.2",
         "create-error-class": "^3.0.2",
@@ -3929,6 +3934,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3936,12 +3942,14 @@
     "node_modules/@sanity/client/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/@sanity/client/node_modules/nano-pubsub": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nano-pubsub/-/nano-pubsub-2.0.1.tgz",
-      "integrity": "sha512-RWgGP2TdeKZLx+guR5a7/BzYs85sj6yrXXyj0o/znbgzPlz/Ez9wQuKDpwUZ8q+u2RxXpqZ1iTkPXCIU+GHhpA=="
+      "integrity": "sha512-RWgGP2TdeKZLx+guR5a7/BzYs85sj6yrXXyj0o/znbgzPlz/Ez9wQuKDpwUZ8q+u2RxXpqZ1iTkPXCIU+GHhpA==",
+      "dev": true
     },
     "node_modules/@sanity/color": {
       "version": "2.2.2",
@@ -5102,10 +5110,11 @@
         "styled-components": "^5.2"
       }
     },
-    "node_modules/@sanity/schema": {
+    "node_modules/@sanity/portable-text-editor/node_modules/@sanity/schema": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.3.1.tgz",
       "integrity": "sha512-8BzRzV+jckwVjhltiZe1Z7cCXjMRZZyfEeqDm3rLN9cw7ahplyD4j1vxX9Re7f8iGrqByBF0RO5hIKhqfsDCZQ==",
+      "dev": true,
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
         "@sanity/types": "3.3.1",
@@ -5114,6 +5123,174 @@
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
         "object-inspect": "^1.6.0"
+      }
+    },
+    "node_modules/@sanity/schema": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.4.0.tgz",
+      "integrity": "sha512-4qfESr1E6V6yIRxmnDMvuhE9s4KCzrQSmg54dOLqrvOC/rOhe86kbYRnXyYoazsu/F9uXUNSJzc+4bvHYzOahQ==",
+      "dependencies": {
+        "@sanity/generate-help-url": "^3.0.0",
+        "@sanity/types": "3.4.0",
+        "arrify": "^1.0.1",
+        "humanize-list": "^1.0.1",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.21",
+        "object-inspect": "^1.6.0"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/@sanity/client": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-5.4.2.tgz",
+      "integrity": "sha512-M/ebzTGwYq+NDGMfBWxKtwtmCRJbBvXxAIQXu/J0vxnr8mXKw8gBQ7GaG0tI4WJ54w5sI6pnrD6mPiKdRHVNYw==",
+      "dependencies": {
+        "@sanity/eventsource": "5",
+        "get-it": "^8.1",
+        "rxjs": "7"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/@sanity/eventsource": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.0.tgz",
+      "integrity": "sha512-0ewT+BDzfiamHwitUfRcwsl/RREHjWv6VNZvQ8Q4OnnNKXfEEGXbWmqzof0okOTkp4XELgyliht4Qj28o9AU2g==",
+      "dependencies": {
+        "@types/event-source-polyfill": "1.0.1",
+        "@types/eventsource": "1.1.11",
+        "event-source-polyfill": "1.0.31",
+        "eventsource": "2.0.2"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/@sanity/types": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.4.0.tgz",
+      "integrity": "sha512-d3vul0wZqVYHmqqtVYDgcUDe4tUdFGnronpM17652wWDk1HuQjskq94Gv49rGDuXi2k41ZlmvW7Y9HDJDu3n2Q==",
+      "dependencies": {
+        "@sanity/client": "^5.2.0",
+        "@types/react": "^18.0.25"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/decompress-response": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
+      "integrity": "sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA=="
+    },
+    "node_modules/@sanity/schema/node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/get-it": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.3.1.tgz",
+      "integrity": "sha512-fi5wQakZVHWRy3zP0env52PHXP9Zl/p8Q2Ow8z9SmwpYgfCaA90hCSW2twC5/cpV5M1wB6tSmLqldVMP1tS1qw==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "decompress-response": "^7.0.0",
+        "follow-redirects": "^1.15.2",
+        "into-stream": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "is-retry-allowed": "^2.2.0",
+        "is-stream": "^2.0.1",
+        "parse-headers": "^2.0.5",
+        "progress-stream": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/into-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
+      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
+      "dependencies": {
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/@sanity/schema/node_modules/p-is-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@sanity/semantic-release-preset": {
@@ -5184,6 +5361,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@sanity/timed-out/-/timed-out-4.0.2.tgz",
       "integrity": "sha512-NBDKGj14g9Z+bopIvZcQKWCzJq5JSrdmzRR1CS+iyA3Gm8SnIWBfZa7I3mTg2X6Nu8LQXG0EPKXdOGozLS4i3w==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5192,6 +5370,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.3.1.tgz",
       "integrity": "sha512-ThbGGtPbiDM0xmD2XZejO07lkYj/5ZFJ8KgFuvNoRAbqPlY52LoZNsxJm1T/IDZcetX+/TwmOLCKxeu9767QJw==",
+      "dev": true,
       "dependencies": {
         "@sanity/client": "^4.0.1",
         "@types/react": "^18.0.25"
@@ -5559,6 +5738,16 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "node_modules/@types/event-source-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.1.tgz",
+      "integrity": "sha512-dls8b0lUgJ/miRApF0efboQ9QZnAm7ofTO6P1ILu8bRPxUFKDxVwFf8+TeuuErmNui6blpltyr7+eV72dbQXlQ=="
+    },
+    "node_modules/@types/eventsource": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.11.tgz",
+      "integrity": "sha512-L7wLDZlWm5mROzv87W0ofIYeQP5K2UhoFnnUyEWLKM6UBb0ZNRgAqp98qE5DkgfBXdWfc2kYmw9KZm4NLjRbsw=="
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -6957,6 +7146,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
       "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7737,6 +7927,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
       "dependencies": {
         "capture-stack-trace": "^1.0.0"
       },
@@ -7953,6 +8144,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -9036,7 +9228,8 @@
     "node_modules/event-source-polyfill": {
       "version": "1.0.25",
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.25.tgz",
-      "integrity": "sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg=="
+      "integrity": "sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg==",
+      "dev": true
     },
     "node_modules/eventsource": {
       "version": "1.1.2",
@@ -9393,7 +9586,8 @@
     "node_modules/form-urlencoded": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-2.0.9.tgz",
-      "integrity": "sha512-fWUzNiOnYa126vFAT6TFXd1mhJrvD8IqmQ9ilZPjkLYQfaRreBr5fIUoOpPlWtqaAG64nzoE7u5zSetifab9IA=="
+      "integrity": "sha512-fWUzNiOnYa126vFAT6TFXd1mhJrvD8IqmQ9ilZPjkLYQfaRreBr5fIUoOpPlWtqaAG64nzoE7u5zSetifab9IA==",
+      "dev": true
     },
     "node_modules/framer-motion": {
       "version": "6.5.1",
@@ -10657,6 +10851,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "dev": true,
       "dependencies": {
         "from2": "^2.1.1",
         "p-is-promise": "^1.1.0"
@@ -11070,6 +11265,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
       "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11090,6 +11286,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12787,7 +12984,8 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -13729,6 +13927,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -14538,7 +14737,8 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -15034,7 +15234,8 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -15328,7 +15529,8 @@
     "node_modules/same-origin": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/same-origin/-/same-origin-0.1.1.tgz",
-      "integrity": "sha1-wih9MZJXffUXrLvW0UUanDw5FPU="
+      "integrity": "sha1-wih9MZJXffUXrLvW0UUanDw5FPU=",
+      "dev": true
     },
     "node_modules/sanity": {
       "version": "3.3.1",
@@ -15483,6 +15685,21 @@
       },
       "peerDependencies": {
         "react": "^18"
+      }
+    },
+    "node_modules/sanity/node_modules/@sanity/schema": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.3.1.tgz",
+      "integrity": "sha512-8BzRzV+jckwVjhltiZe1Z7cCXjMRZZyfEeqDm3rLN9cw7ahplyD4j1vxX9Re7f8iGrqByBF0RO5hIKhqfsDCZQ==",
+      "dev": true,
+      "dependencies": {
+        "@sanity/generate-help-url": "^3.0.0",
+        "@sanity/types": "3.3.1",
+        "arrify": "^1.0.1",
+        "humanize-list": "^1.0.1",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.21",
+        "object-inspect": "^1.6.0"
       }
     },
     "node_modules/sanity/node_modules/@tootallnate/once": {
@@ -16294,6 +16511,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -17600,6 +17818,7 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -20956,6 +21175,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@sanity/client/-/client-4.0.1.tgz",
       "integrity": "sha512-Sd/oGzDsZulodtjq54wOFoMSvUrNnXkvevAGmuLmO90givXHzEyMMUFSj/BmG6TV1mKigS0m6gmFDP/dalUHjg==",
+      "dev": true,
       "requires": {
         "@sanity/eventsource": "^4.0.0",
         "get-it": "^7.0.2",
@@ -20967,6 +21187,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-4.0.0.tgz",
           "integrity": "sha512-W0AD141JILOySJ177j2+HTr5k4tWNyXjGsr0dDXJzpqlwZ09J/uPHI73hMe5XtoFumPa9Bj6jy8uu2qdZX84NQ==",
+          "dev": true,
           "requires": {
             "event-source-polyfill": "1.0.25",
             "eventsource": "^2.0.2"
@@ -20976,6 +21197,7 @@
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
           "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -20983,12 +21205,14 @@
         "eventsource": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
-          "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
+          "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+          "dev": true
         },
         "get-it": {
           "version": "7.0.2",
           "resolved": "https://registry.npmjs.org/get-it/-/get-it-7.0.2.tgz",
           "integrity": "sha512-q4d+ssYtpWzC4/qJ4aJDZ5yWl94BIGmRER7PEvYpiKCBoCoDnl1YygEvNHQ2tHbD3GVZaq3QonKGi6Puh1Hzkw==",
+          "dev": true,
           "requires": {
             "@sanity/timed-out": "^4.0.2",
             "create-error-class": "^3.0.2",
@@ -21012,17 +21236,20 @@
         "is-plain-object": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         },
         "nano-pubsub": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/nano-pubsub/-/nano-pubsub-2.0.1.tgz",
-          "integrity": "sha512-RWgGP2TdeKZLx+guR5a7/BzYs85sj6yrXXyj0o/znbgzPlz/Ez9wQuKDpwUZ8q+u2RxXpqZ1iTkPXCIU+GHhpA=="
+          "integrity": "sha512-RWgGP2TdeKZLx+guR5a7/BzYs85sj6yrXXyj0o/znbgzPlz/Ez9wQuKDpwUZ8q+u2RxXpqZ1iTkPXCIU+GHhpA==",
+          "dev": true
         }
       }
     },
@@ -21780,20 +22007,146 @@
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
         "slate": "0.81.1"
+      },
+      "dependencies": {
+        "@sanity/schema": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.3.1.tgz",
+          "integrity": "sha512-8BzRzV+jckwVjhltiZe1Z7cCXjMRZZyfEeqDm3rLN9cw7ahplyD4j1vxX9Re7f8iGrqByBF0RO5hIKhqfsDCZQ==",
+          "dev": true,
+          "requires": {
+            "@sanity/generate-help-url": "^3.0.0",
+            "@sanity/types": "3.3.1",
+            "arrify": "^1.0.1",
+            "humanize-list": "^1.0.1",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "object-inspect": "^1.6.0"
+          }
+        }
       }
     },
     "@sanity/schema": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.3.1.tgz",
-      "integrity": "sha512-8BzRzV+jckwVjhltiZe1Z7cCXjMRZZyfEeqDm3rLN9cw7ahplyD4j1vxX9Re7f8iGrqByBF0RO5hIKhqfsDCZQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.4.0.tgz",
+      "integrity": "sha512-4qfESr1E6V6yIRxmnDMvuhE9s4KCzrQSmg54dOLqrvOC/rOhe86kbYRnXyYoazsu/F9uXUNSJzc+4bvHYzOahQ==",
       "requires": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.3.1",
+        "@sanity/types": "3.4.0",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
         "object-inspect": "^1.6.0"
+      },
+      "dependencies": {
+        "@sanity/client": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@sanity/client/-/client-5.4.2.tgz",
+          "integrity": "sha512-M/ebzTGwYq+NDGMfBWxKtwtmCRJbBvXxAIQXu/J0vxnr8mXKw8gBQ7GaG0tI4WJ54w5sI6pnrD6mPiKdRHVNYw==",
+          "requires": {
+            "@sanity/eventsource": "5",
+            "get-it": "^8.1",
+            "rxjs": "7"
+          }
+        },
+        "@sanity/eventsource": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.0.tgz",
+          "integrity": "sha512-0ewT+BDzfiamHwitUfRcwsl/RREHjWv6VNZvQ8Q4OnnNKXfEEGXbWmqzof0okOTkp4XELgyliht4Qj28o9AU2g==",
+          "requires": {
+            "@types/event-source-polyfill": "1.0.1",
+            "@types/eventsource": "1.1.11",
+            "event-source-polyfill": "1.0.31",
+            "eventsource": "2.0.2"
+          }
+        },
+        "@sanity/types": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.4.0.tgz",
+          "integrity": "sha512-d3vul0wZqVYHmqqtVYDgcUDe4tUdFGnronpM17652wWDk1HuQjskq94Gv49rGDuXi2k41ZlmvW7Y9HDJDu3n2Q==",
+          "requires": {
+            "@sanity/client": "^5.2.0",
+            "@types/react": "^18.0.25"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "decompress-response": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
+          "integrity": "sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==",
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "event-source-polyfill": {
+          "version": "1.0.31",
+          "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+          "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA=="
+        },
+        "eventsource": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+          "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
+        },
+        "get-it": {
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.3.1.tgz",
+          "integrity": "sha512-fi5wQakZVHWRy3zP0env52PHXP9Zl/p8Q2Ow8z9SmwpYgfCaA90hCSW2twC5/cpV5M1wB6tSmLqldVMP1tS1qw==",
+          "requires": {
+            "debug": "^4.3.4",
+            "decompress-response": "^7.0.0",
+            "follow-redirects": "^1.15.2",
+            "into-stream": "^6.0.0",
+            "is-plain-object": "^5.0.0",
+            "is-retry-allowed": "^2.2.0",
+            "is-stream": "^2.0.1",
+            "parse-headers": "^2.0.5",
+            "progress-stream": "^2.0.0",
+            "tunnel-agent": "^0.6.0"
+          }
+        },
+        "into-stream": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
+          "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
+          "requires": {
+            "from2": "^2.3.0",
+            "p-is-promise": "^3.0.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        },
+        "is-retry-allowed": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+          "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
+        },
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "p-is-promise": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+          "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ=="
+        }
       }
     },
     "@sanity/semantic-release-preset": {
@@ -21851,12 +22204,14 @@
     "@sanity/timed-out": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@sanity/timed-out/-/timed-out-4.0.2.tgz",
-      "integrity": "sha512-NBDKGj14g9Z+bopIvZcQKWCzJq5JSrdmzRR1CS+iyA3Gm8SnIWBfZa7I3mTg2X6Nu8LQXG0EPKXdOGozLS4i3w=="
+      "integrity": "sha512-NBDKGj14g9Z+bopIvZcQKWCzJq5JSrdmzRR1CS+iyA3Gm8SnIWBfZa7I3mTg2X6Nu8LQXG0EPKXdOGozLS4i3w==",
+      "dev": true
     },
     "@sanity/types": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.3.1.tgz",
       "integrity": "sha512-ThbGGtPbiDM0xmD2XZejO07lkYj/5ZFJ8KgFuvNoRAbqPlY52LoZNsxJm1T/IDZcetX+/TwmOLCKxeu9767QJw==",
+      "dev": true,
       "requires": {
         "@sanity/client": "^4.0.1",
         "@types/react": "^18.0.25"
@@ -22151,6 +22506,16 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "@types/event-source-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.1.tgz",
+      "integrity": "sha512-dls8b0lUgJ/miRApF0efboQ9QZnAm7ofTO6P1ILu8bRPxUFKDxVwFf8+TeuuErmNui6blpltyr7+eV72dbQXlQ=="
+    },
+    "@types/eventsource": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.11.tgz",
+      "integrity": "sha512-L7wLDZlWm5mROzv87W0ofIYeQP5K2UhoFnnUyEWLKM6UBb0ZNRgAqp98qE5DkgfBXdWfc2kYmw9KZm4NLjRbsw=="
     },
     "@types/glob": {
       "version": "7.2.0",
@@ -23183,7 +23548,8 @@
     "capture-stack-trace": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+      "dev": true
     },
     "chalk": {
       "version": "4.1.2",
@@ -23776,6 +24142,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
       "requires": {
         "capture-stack-trace": "^1.0.0"
       }
@@ -23956,6 +24323,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "requires": {
         "mimic-response": "^3.1.0"
       }
@@ -24736,7 +25104,8 @@
     "event-source-polyfill": {
       "version": "1.0.25",
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.25.tgz",
-      "integrity": "sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg=="
+      "integrity": "sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg==",
+      "dev": true
     },
     "eventsource": {
       "version": "1.1.2",
@@ -25018,7 +25387,8 @@
     "form-urlencoded": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-2.0.9.tgz",
-      "integrity": "sha512-fWUzNiOnYa126vFAT6TFXd1mhJrvD8IqmQ9ilZPjkLYQfaRreBr5fIUoOpPlWtqaAG64nzoE7u5zSetifab9IA=="
+      "integrity": "sha512-fWUzNiOnYa126vFAT6TFXd1mhJrvD8IqmQ9ilZPjkLYQfaRreBr5fIUoOpPlWtqaAG64nzoE7u5zSetifab9IA==",
+      "dev": true
     },
     "framer-motion": {
       "version": "6.5.1",
@@ -25999,6 +26369,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "dev": true,
       "requires": {
         "from2": "^2.1.1",
         "p-is-promise": "^1.1.0"
@@ -26278,7 +26649,8 @@
     "is-retry-allowed": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "dev": true
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
@@ -26292,7 +26664,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.7",
@@ -27599,7 +27972,8 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.12",
@@ -28319,7 +28693,8 @@
     "p-is-promise": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+      "dev": true
     },
     "p-limit": {
       "version": "2.3.0",
@@ -28921,7 +29296,8 @@
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -29306,7 +29682,8 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
     },
     "resolve": {
       "version": "1.22.1",
@@ -29510,7 +29887,8 @@
     "same-origin": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/same-origin/-/same-origin-0.1.1.tgz",
-      "integrity": "sha1-wih9MZJXffUXrLvW0UUanDw5FPU="
+      "integrity": "sha1-wih9MZJXffUXrLvW0UUanDw5FPU=",
+      "dev": true
     },
     "sanity": {
       "version": "3.3.1",
@@ -29634,6 +30012,21 @@
           "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.2.2.tgz",
           "integrity": "sha512-+Ks6LeYe44kjZSfcWFWj0zQRP48N3JisrZ9ia44QwG11y6bO9Wk8bfhu5o23FkyYrREu9CzQ0U+slSV7YsvcuQ==",
           "dev": true
+        },
+        "@sanity/schema": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.3.1.tgz",
+          "integrity": "sha512-8BzRzV+jckwVjhltiZe1Z7cCXjMRZZyfEeqDm3rLN9cw7ahplyD4j1vxX9Re7f8iGrqByBF0RO5hIKhqfsDCZQ==",
+          "dev": true,
+          "requires": {
+            "@sanity/generate-help-url": "^3.0.0",
+            "@sanity/types": "3.3.1",
+            "arrify": "^1.0.1",
+            "humanize-list": "^1.0.1",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "object-inspect": "^1.6.0"
+          }
         },
         "@tootallnate/once": {
           "version": "2.0.0",
@@ -30242,7 +30635,8 @@
     "simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true
     },
     "simple-update-notifier": {
       "version": "1.1.0",
@@ -31214,6 +31608,7 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@sanity/block-tools": "^3.3.1",
     "@sanity/incompatible-plugin": "^1.0.4",
     "@sanity/mutator": "^3.3.1",
-    "@sanity/schema": "3.3.1",
+    "@sanity/schema": "3.4.0",
     "just-clone": "^6.2.0",
     "sanity": "^3"
   },


### PR DESCRIPTION
v3.4.0 is the [next-newest version](https://github.com/sanity-io/sanity/commits/next?after=a735461ff39cb34626ac7053049520e6d3af48c2+34&branch=next&path%5B%5D=packages&path%5B%5D=@sanity&path%5B%5D=schema&qualified_name=refs/heads/next) after v3.3.1.

resolves #59 